### PR TITLE
Poniendo todos los títulos en mayúsculas y quitándoles el punto final

### DIFF
--- a/txt/02.datos.md
+++ b/txt/02.datos.md
@@ -10,13 +10,13 @@ empieza a teclear números y palabras
 
 	>>> 3
 	>>> "cosas"
-	
+
 Las palabras llevarán comillas alrededor. Incluso aunque se trate de
 una sola letra. El intérprete se *acuerda* de lo último que has
 tecleado
 
-	>>> _ 
-	
+	>>> _
+
 ![Usando el subrayado para recordar lo último tecleado](../img/_.png).
 
 Podemos pasar así el día, así que vamos a empezar a hacer algo con
@@ -28,7 +28,7 @@ Nada inesperado en este
 área. [Suma, resta, multiplicación y división](https://en.wikibooks.org/wiki/Python_Programming/Basic_Math#Mathematical_Operators)
 
 	>>> 3*8+5.2**8
-		
+
 dará un número bastante grande, teniendo en cuenta que `**` es
 *elevado a*, es decir, `2**8` es 2 a la octava potencia. En esto no se
 diferencia de otros lenguajes. Por ejemplo, si abres la consola de
@@ -36,10 +36,10 @@ desarrollo en tu navegador (con mayúsculas-control-k en Firefox, por
 ejemplo), tendrás el mismo resultado, aunque estaremos trabajando en JavaScript.
 
 ![Resultado en la consola de desarrollo de JavaScript](../img/js-resultado.png).
-	
+
 Los números no son todos iguales. Los enteros y los números reales
 (los que tienen coma decimal) se comportarán de forma diferente,
-aunque no habrá que preocuparse (demasiado) por ello ahora mismo. 
+aunque no habrá que preocuparse (demasiado) por ello ahora mismo.
 
 ```python
 >>> type(3)
@@ -82,7 +82,7 @@ type(800//20)
 De camino,
 vemos la primera función: `type`. Las funciones en Python llevan
 siempre paréntesis y tienen una serie de argumentos que, en su caso,
-se separarán por comas. 
+se separarán por comas.
 
 Y también de camino, vemos el concepto
 de
@@ -144,7 +144,7 @@ todavía no han llegado a hacerlo.
 
 Afortunadamente, Python no sólo trabaja con números. También puede
 
-## Trabajar con cualquier tipo de caracteres.
+## Trabajar con cualquier tipo de caracteres
 
 Pero vamos a dar un paso hacia atrás, o hacia un lado, para reconocer
 que existen letras más allá de nuestro alfabeto latino. Empezando por
@@ -155,9 +155,9 @@ lenguaje de programación moderno, y un ordenador moderno, debe ser
 capaz de trabajar con todos ellos.
 
 	"þor el poderoso ✌"
-	
+
 Como hemos visto más arriba, las cadenas o *strings* están rodeadas
-por comillas. 
+por comillas.
 
 >Hemos elegido þ como carácter raro porque es uno de los pocos de este
 >tipo que se pueden teclear fácilmente desde el teclado castellano. þ
@@ -178,9 +178,9 @@ Las cadenas están compuestas por caracteres, y podemos acceder a ellos
 indicando su índice, que comienza por 0: ` "þor el poderoso ✌"[16]`
 devolverá ✌. También podemos acceder a grupos de caracteres, usando el
 rango `x:y`. `_[0:3]` nos devolverá los 4 primeros caracteres de la
-última cadena, lo que es equivalente a  `_[:3]`. 
+última cadena, lo que es equivalente a  `_[:3]`.
 
-Los operadores aritméticos también se pueden usar sobre cadenas. 
+Los operadores aritméticos también se pueden usar sobre cadenas.
 
 >Cuando un operador se puede aplicar sobre tipos diferentes se dice
 >que está *sobrecargado*. En muchos lenguajes también puede definir el
@@ -199,7 +199,7 @@ _ + " y Loki el mentiroso ❄"
 
 y el asterisco `*`, usado tradicionalmente como símbolo para
 multiplicar, en este caso las replicará `"þor, " * 3 + "y más þor"`
-resultará en la cadena `'þor, þor, þor, y más þor'`. 
+resultará en la cadena `'þor, þor, þor, y más þor'`.
 
 El tipo de estas cadenas es `str`. ¿Y qué ocurre cuando tratamos de
 mezclarlas con los números? Pues que resulta en un error.
@@ -213,7 +213,7 @@ una cadena a un número, así que simplemente expresa su disconformidad
 con el asunto, diciendo que se trata de un `TypeError`. Pero error es
 una palabra un poco fuerte.
 
-## Hablemos de los problemas de entendimiento.
+## Hablemos de los problemas de entendimiento
 
 En el caso anterior, el intérprete nos ha dicho: `TypeError: must be
 str, not int`. Pero es leer la palabra **error** y uno empieza a
@@ -235,7 +235,7 @@ in "3.4" + 7 : argumento no-numérico para operador binario`. No le
 gusta la cadena y no tiene reparos en decirlo, porque R es un lenguaje
 estadístico, y por tanto (casi) matemático. Perl, sin embargo, llevará
 el *tipado pato* hasta las últimas consecuencias, dando como resultado
-10.4. 
+10.4.
 
 Lo que viene a querer decir que lenguajes diferentes van a entender
 esa expresión, forzosamente ambigua, de forma diferente. Pero si no la entienden,
@@ -254,7 +254,7 @@ TypeError: unsupported operand type(s) for +: 'int' and 'str'
 que es algo más informativo. Ya no te está diciendo que el entero es
 un error, sino que alguno de los dos está equivocado. En las líneas
 anteriores, además, te indica dónde ha ocurrido, aunque `File
-"<stdin>", line 1, in <module>`no sea demasiado amigable. 
+"<stdin>", line 1, in <module>`no sea demasiado amigable.
 
 En todo caso, estos mensajes te ayudan a entender dónde ha producido
 el malentendido y de qué se trata. Aunque estén en inglés (en la
@@ -275,14 +275,14 @@ a
 verás contextos similares y una solución al problema. En este caso, te
 viene a decir que hay que hacer una conversión explícita:
 `7+float("3.4")`, lo que está totalmente de acuerdo
-con [el *zen* de Python](https://hipertextual.com/2011/02/zen-python): 
+con [el *zen* de Python](https://hipertextual.com/2011/02/zen-python):
 
 	>Explícito antes que implícito
-	
+
 Y, por supuesto, toda esta sección se corresponde al de
 
 	>Los errores no deben suceder en silencio
-	
+
 Como conclusión a esta sección: si el ordenador no te entiende y te
 lo dice cortésmente, lee, comprende, trata de adaptarte a lo que
 requiere, pero si todo falla, Google es tu amigo.
@@ -292,9 +292,4 @@ requiere, pero si todo falla, Google es tu amigo.
 No es malo equivocarse. Sucede en las mejores familias, incluso en las
 operaciones más básicas. Para las cuales puedes usar Python como si
 fuera una calculadora un poco más complicada y que usara, además,
-cadenas de caracteres. Vale, una calculadora complicada *y* rara. 
-
-
-
-
-
+cadenas de caracteres. Vale, una calculadora complicada *y* rara.

--- a/txt/03.logica.md
+++ b/txt/03.logica.md
@@ -29,9 +29,9 @@ type(True)
 ```
 
 Por sí solos los tipos booleanos tampoco son tan útiles. Pero sí lo son
-para hacer 
+para hacer
 
-## Operaciones lógicas.
+## Operaciones lógicas
 
 Conviene recordar que, para empezar, todo valor tiene un equivalente
 lógico. Estas operaciones no se tienen por qué hacer, necesariamente,
@@ -43,7 +43,7 @@ False
 ```
 
 `not` cambia lo verdadero a falso y lo falso a verdadero, pero siempre
-devolverá un booleano. 
+devolverá un booleano.
 
 ```python
 not(None)
@@ -86,7 +86,7 @@ equivale a Falso. Con `or` sucederá algo similar:
 tanto es falso) y otro verdadero, devolverá el que sea
 verdadero, o uno de ellos operando si los dos tienen el mismo tipo. A
 `or` le basta con que sea cierto uno de los operandos, como se ve
-arriba. 
+arriba.
 
 >Curiosamente, `or` devuelve el segundo operando si el resultado es
 >falso, y el primero si el resultado es True. Eso puede tener que ver
@@ -97,18 +97,18 @@ arriba.
 >evaluar el segundo resultado. En el caso de `or`, aunque el primer operando sea falso, hay
 >que evaluar también el segundo, pero si el primero es verdadero, el
 >resultado va a ser verdadero, así que simplemente devuelven el último
->operando evaluado. 
+>operando evaluado.
 
 Aunque estas operaciones se usan con asiduidad, las que tienen más
 interés son las operaciones de comparación que dan un resultado
-Verdadero o Falso. 
+Verdadero o Falso.
 
 >*Ejercicio*: se dice que una fórmula es ["satisfacible"](https://es.wikipedia.org/wiki/Problema_de_satisfacibilidad_booleana) si es
 >verdadera al menos para una combinación de valores. Con una fórmula
 >de 3 variables, ¿cuantas combinaciones posibles de valores hay?
 >Diseña una fórmula y pruébala sistemáticamente hasta que encuentres
 >si es satisfacible o no. Altérala y conviértela en no-satisfacible,
->probándola también sistemáticamente. 
+>probándola también sistemáticamente.
 
 Hay
 más
@@ -146,12 +146,12 @@ csharp> true?"Yay":"Nay"
 El orden es igual que en el anterior: antes del símbolo de
 interrogación está la condición; si es cierta, el resultado será
 `"Yay"`, si no, `"Nay"`. Efectivamente, el resultado de la aplicación
-de este, o *el*, operador ternario, es el esperable. 
+de este, o *el*, operador ternario, es el esperable.
 
 
 
 
-## Comparaciones no odiosas.
+## Comparaciones no odiosas
 
 Algunas operaciones también devuelven un valor lógico: verdadero o falso. Un número es mayor o igual que otro, por ejemplo.
 
@@ -193,7 +193,7 @@ La solución a
 esto
 [no es demasiado simple](https://stackoverflow.com/questions/1097908/how-do-i-sort-unicode-strings-alphabetically-in-python). Por
 lo pronto simplemente conviene tratar de evitar la sorpresa cuando se
-usen caracteres que no sean los 23 del alfabeto inglés. 
+usen caracteres que no sean los 23 del alfabeto inglés.
 
 > *Ejercicio*: Escribe una expresión que sea cierta (es decir, sea `True`) si un número está en un intervalo comprendido entre dos números naturales.
 
@@ -216,17 +216,17 @@ tiene un operador para cada una: `==` e `===`. El que se usen varios
 signos `=` en vez de uno solo es porque este se suele reservar para
 asignaciones, y es un error bastante habitual poner `x = y` en vez de
 `x == y`. Algunos compiladores e intérpretes, incluso, avisan en
-ciertas circunstancias del posible error. Son muy majetes. 
+ciertas circunstancias del posible error. Son muy majetes.
 
 Para expresar desigualdad, `!=` es también símbolo cuasi-universal. En
-Python se puede usar con cualquier tipo de dato. 
+Python se puede usar con cualquier tipo de dato.
 
 > *Ejercicio*: Usando sólo los símbolos de mayor y menor y operadores
 > lógicos (`and` y `or`), construir
 > una expresión que sea equivalente a `!=`. Probar con diferentes
-> valores que efectivamente es así. 
+> valores que efectivamente es así.
 
-## Dos veces no es sí.
+## Dos veces no es sí
 
 Los operadores que se sitúan entre dos operandos se llaman
 binarios. `<=`, por ejemplo, es un operador binario
@@ -258,7 +258,7 @@ cuasi-universal del `!`
 
 En Python nos lo encontramos dentro de la comparación `!=`. ¿Por qué
 no se usa `not`? [Porque *simple es mejor que complicado*](https://hipertextual.com/2011/02/zen-python) y `x != y`
-es más simple que `not x == y`. 
+es más simple que `not x == y`.
 
 > *Ejercicio*: probar, usando todos los casos posibles,
 > las
@@ -280,16 +280,16 @@ mínimo número de *conectores* posibles. Y resulta que `NAND`, donde `a
 NAND b == not (a and b)`, es suficiente para expresar absolutamente
 todos los operadores lógicos unarios y binarios. En este caso el
 paréntesis hace que se ejecute primero el `a and b` antes que el not;
-la precedencia más alta del `not` obliga a que se haga de esta forma. 
+la precedencia más alta del `not` obliga a que se haga de esta forma.
 
 > *Ejercicio*: expresar `and`, `or` y `not` usando sólo NAND y probar
 > exhaustivamente, usando valores de True y False, que es así.
 
 Al final, los lenguajes de programación son lenguajes que te permiten
 expresar y resolver problemas. Enseñar a pensar usando ordenadores se
-denomina 
+denomina
 
-## Pensamiento computacional,
+## Pensamiento computacional
 
 y se basa
 en
@@ -321,7 +321,7 @@ Perl6:
 
 ```Ruby
  :002 > (3+4i)*(5+0.1i)
- => (14.6+20.3i) 
+ => (14.6+20.3i)
 ```
 
 *A priori*, es complejo pensar en algún problema "del mundo real" que
@@ -332,7 +332,7 @@ forma más eficiente de trabajar es usando estos números
 complejos. Trabajando en la línea de órdenes:
 
 ```Python
->>>1+3.14j 
+>>>1+3.14j
 
 >>> _*(1+3.14j)
 _*(1+3.14j)
@@ -368,10 +368,10 @@ segunda es tratar de conseguir partes de un número usando operaciones
 con 5s. Cero, por ejemplo, es 5-5. Uno, 5/5. Esta no es la solución a
 los dos primeros, pero sí para el tercero, 2 == 5/5 + 5/5. ¿Y cómo
 haríamos 5? Teniendo en cuenta que cualquier cosa multiplicada por 0
-es cero... 
+es cero...
 
 > *Ejercicio*: usa sólo cuatro números 5 para reconstruir los números del 0
-> al 5. Si puedes, hazlo hasta el 10. 
+> al 5. Si puedes, hazlo hasta el 10.
 
 
 El último mecanismo, el *reconocimiento de patrones*, se aleja más de
@@ -379,7 +379,7 @@ lo puramente computacional, siendo simplemente una herramienta del
 pensamiento crítico. Pero eso no quiere decir que no sea útil. Por
 ejemplo, muchas de las técnicas, o la mayoría, de las usadas en el
 ejercicio anterior, ¿se podrían usar con cualquier otro número, es
-decir, sustituyendo el 5 por el 4 o por el 7? 
+decir, sustituyendo el 5 por el 4 o por el 7?
 
 > *Ejercicio*: ¿Para qué números se pueden usar más o menos los mismos
 > patrones que para el 5? ¿Funciona con el 4? ¿Funciona con el 6?
@@ -390,9 +390,9 @@ Como parte de la descomposición mencionada anteriormente está el hecho
 de que, eventualmente, toda la información que hay en un ordenador se
 reduce a puertas lógicas que pueden tomar un valor 0 o 1, verdad o
 mentira. Por eso casi todos los lenguajes de programación tienen
-operadores que permiten trabajar con los números 
+operadores que permiten trabajar con los números
 
-## a nivel de bit.
+## A nivel de bit
 
 Trabajar con números en su representación binaria muchas veces es
 la forma más rápida de hacer ciertas pruebas; dado que, de hecho, el
@@ -430,7 +430,7 @@ Así, '<<' puede ser una forma rápida de hallar potencias de 2
 ```
 
 Hay otros dos operadores que son equivalentes a *or* y *not*, `|` y
-`~` a nivel binario. Además, el siguiente operador es bastante interesante: `XOR`. 
+`~` a nivel binario. Además, el siguiente operador es bastante interesante: `XOR`.
 Se trata de un
 operador lógico que es 1 cuando uno de los dos operandos es 1, pero no
 cuando lo son los dos, se denomina *o exclusivo* o *exclusive or*, de
@@ -446,7 +446,7 @@ de un número puede ser la siguiente:
 `1 << 3` correspondería al número binario `100`, es decir, 1 corrido
 tres posiciones. 32 es el número binario `10000`. `32 ^ 8` es `10000 ^
 100`, es decir, cambiaría el tercer bit (empezando por izquierda o derecha,
-da igual), que convertiría el número en el 40 que vemos. 
+da igual), que convertiría el número en el 40 que vemos.
 
 En otros lenguajes, como [Lua](http://lua.org), se usan exactamente
 los mismos símbolos para el mismo tipo de operadores. Estos
@@ -464,17 +464,17 @@ en Python. El truco aquí es simplemente darse cuenta de que `>> 1` es
 como una división entera por dos. Esto no funciona si alguno de
 los números es impar, pero si se trabaja sólo con enteros sería una
 forma muy rápida, ya que se hace directamente en el procesador usando
-instrucciones del mismo, de realizar esta operación. 
+instrucciones del mismo, de realizar esta operación.
 
 > *Ejercicio* Usando `xor`, comprobar si dos números enteros tienen el
-> mismo signo. 
+> mismo signo.
 
 
 Es muy probable que en el ejercicio anterior hayas tenido buscar en
 Internet. Si lo has hecho, te habrás dado cuenta de que
 
-## Todo está en StackOverflow.
- 
+## Todo está en StackOverflow
+
 Para qué vamos a engañarnos, seguro que siguiendo este tutorial o,
 para el caso, cualquier otro, habéis consultado una o más veces Google
 buscando cómo hacer algo. Un dominio ligero del inglés y una conexión
@@ -490,7 +490,7 @@ Muchas de las respuestas van a estar
 en [StackOverflow](http://stackoverflow.com), que se inició como un
 sitio de preguntas y respuestas pero que eventualmente ha evolucionado
 en una serie de sitios de diferentes temas, desde la historia hasta la
-estadística pasando por LaTeX o, por supuesto, programación. 
+estadística pasando por LaTeX o, por supuesto, programación.
 
 StackOverflow tiene un sistema de puntuaciones por parte de los
 usuarios que pone como mejor respuesta la mejor puntuada; eso te
@@ -511,20 +511,20 @@ tienes alguna duda, no sin antes hacer lo siguiente:
 
 1. Buscar exhaustivamente por todo Google y el propio StackOverflow
    por una respuesta a esa pregunta y algunas más generales.
-   
+
 2. Reducir al mínimo el error o el problema que tengas. No puedes
    subir 200 líneas de código y esperar que alguien se las lea. Si el
    error está en 2 líneas, pues mucho mejor.
-   
+
 3. Poner de forma precisa cuál es el error: mensaje de error completo
    o de forma precisa qué es lo que quieres hacer y no puedes. Durante
    este proceso el propio StackOverflow te sugerirá otras
    posibilidades. Léelas con cuidado, porque es posible que esté la
-   respuesta. 
-   
+   respuesta.
+
 4. Una vez hecha la pregunta, difúndela por las redes sociales. Se
    hacen miles de preguntas en StackOverflow. Una puede pasar sin
-   pena, gloria ni solución. La difusión ayuda. 
+   pena, gloria ni solución. La difusión ayuda.
 
 Una vez que empieces a hacerlo, te convertirás en un verdadero experto
 y comprenderás el chiste que circula diciendo que los cursos de

--- a/txt/03.logica.md
+++ b/txt/03.logica.md
@@ -452,7 +452,7 @@ En otros lenguajes, como [Lua](http://lua.org), se usan exactamente
 los mismos símbolos para el mismo tipo de operadores. Estos
 operadores, al no ser *naturales* como la suma o la resta, se prestan
 a la creatividad por parte de los diseñadores de los lenguajes. Por
-ejemplo, en Lua hallaríamos la media de 8 y 15 de esta forma:
+ejemplo, en Lua hallaríamos la media de 8 y 32 de esta forma:
 
 ```Lua
 > (8+32) >> 1

--- a/txt/04.componiendo.md
+++ b/txt/04.componiendo.md
@@ -7,18 +7,18 @@ letras. En matemáticas existen estructuras, como las matrices y
 vectores, que están compuestas de datos más simples, números
 reales. Los árboles son estructuras de datos que son capaces de representar
 cosas tan diversas como un árbol genealógico o la estructura de un
-edificio. 
+edificio.
 
 Todos los lenguajes de programación, o la mayoría, son capaces de
 trabajar con estas estructuras, con una forma de escribirlas o
 sintaxis particular y unas funciones que permiten modificarlas o
 combinarlas. Empezaremos por las
 
-## funciones,
+## Funciones
 
 que especifican qué secuencia de operaciones se debe aplicar a un
 elemento determinado. En Python, las funciones son datos como
-cualquier otro, número o cadena, y se pueden definir usando `lambda`. 
+cualquier otro, número o cadena, y se pueden definir usando `lambda`.
 
 ```Python
 (lambda dato: dato*dato)(3+4j)
@@ -28,7 +28,7 @@ cualquier otro, número o cadena, y se pueden definir usando `lambda`.
 Esta función va a usar `dato` para referirse a los valores que se le
 van a pasar a la función; tras los `:` especifica la operación que va
 a realizar sobre el mismo, que es a la vez el valor que va a
-devolver. En este caso, multiplicará el valor por sí mismo y devolverá el 
+devolver. En este caso, multiplicará el valor por sí mismo y devolverá el
 resultado, o sea, el cuadrado del valor. Los primeros
 paréntesis, que, recordemos, sirven para agrupar operaciones, definen
 esta operación sin nombre; los segundos paréntesis sirven para definir
@@ -38,7 +38,7 @@ valor, aunque podrían ser varios, y devuelve otro valor. No tiene
 *efectos secundarios*: no cambia nada en el exterior, ni siquiera el
 valor de las variables sobre las que trabaja. Recibe una copia de los
 valores con los que la función es llamada, en lo que se denomina *paso por
-valor*, y devuelve otro valor. Simple y elegante. 
+valor*, y devuelve otro valor. Simple y elegante.
 
 A los lenguajes que tienen, aparte de la posibilidad de definir
 funciones como datos *de primera categoría*, otra serie de
@@ -99,12 +99,12 @@ orientados a objetos como C, el estilo funcional es uno de los
 paradigmas predominantes en esta década y posiblemente al principio de
 la siguiente. Conviene conocer los lenguajes de programación
 funcionales, e intentar funcionar de forma funcional (broma totalmente
-intencionada) en el resto de los lenguajes. Incluso en Python. 
+intencionada) en el resto de los lenguajes. Incluso en Python.
 
 Una función es una estructura compleja porque incluye definiciones de
 parámetros y también código. Pero
 
-## vectores, listas y otras estructuras secuenciales
+## Vectores, listas y otras estructuras secuenciales
 
 almacenan grupos de datos que pueden tener alguna relación
 entre ellas. Por ejemplo
@@ -120,7 +120,7 @@ se va a aplicar repetidamente para obtener el resultado. Los tipos son
 diferentes, tan diferentes como se pueda ser, pero a Python le da
 igual. Los corchetes `[]` al principio y al final son los que indican
 que se trata de una lista y las comas separan cada elemento del
-siguiente. 
+siguiente.
 
 Como todo en Python,
 las
@@ -159,7 +159,7 @@ terceto. Es decir, puede ser conveniente que los valores sean
 inmutables, que no
 cambien. Las
 [*tuplas*](http://openbookproject.net/thinkcs/python/english3e/tuples.html) representan
-este tipo de dato que va a ser inalterable a lo largo de su vida. 
+este tipo de dato que va a ser inalterable a lo largo de su vida.
 
 ```Python
 ("A1", 4+5j, lambda dato: dato*dato )
@@ -186,14 +186,14 @@ números complejos como dato base):
 El `'` al principio hace que la lista no se evalúe, porque toda lista,
 siempre, se evalúa en Clojure. Y, como se ha indicado, esa lista no se puede modificar, como
 las tuplas de Python, sólo puede ser evaluada o pasada a una función
-para que genere una nueva lista. 
+para que genere una nueva lista.
 
 En los dos lenguajes y en los dos casos indicados, las listas pueden
 tener elementos homogéneos o heterogéneos. En muchos casos vamos a
 trabajar con elementos del mismo tipo, numéricos por ejemplo. Siempre
 que vayamos a
 
-## procesar listas,
+## Procesar listas
 
 como la siguiente:
 ```
@@ -209,7 +209,7 @@ lista para poder trabajar con él fácilmente. Como generador de listas
 de números, `range` es bastante flexible,
 [pero es inmutable](http://www.mclibre.org/consultar/python/lecciones/python_range.html). Por
 eso necesitamos convertirlo en un tipo mutable para poder trabajar con
-él alterándolo *in situ*. 
+él alterándolo *in situ*.
 
 Por ejemplo, esta expresión nos halla los números divisibles por 11
 entre los 100 primeros:
@@ -228,7 +228,7 @@ del objeto en el argumento, siempre que esto sea posible, claro.
 
 >*Ejercicio*: Listar todos los números que sean potencia de dos entre
 >los 1000 primeros números. ¿Se puede usar una técnica parecida para
->las potencias de tres? 
+>las potencias de tres?
 
 Como generación de sucesiones una vez que uno tiene manera de decidir
 si algo pertenece o no a la sucesión está bien, pero muchas veces lo
@@ -259,7 +259,7 @@ tipos con resultado que, siendo coherentes, son diferentes. `*` se
 puede aplicar a números enteros dando un resultado entero, a reales y
 enteros dando un resultado real, y a enteros y cadenas dando como
 resultado una cadena. Esto no quiere decir que `*` funcione siempre;
-si se trata de multiplicar por un número real, producirá un error. 
+si se trata de multiplicar por un número real, producirá un error.
 
 ![Error con multiplicación con reales](../img/error-float-string.png)
 
@@ -271,11 +271,11 @@ list(map(len,['●●●', '●●●●●●●●●●●●●●●', '●
 [3, 15, 2, 7, 33]
 ```
 
-Que devolverá, de una forma retorcida, los número que había en la
+Que devolverá, de una forma retorcida, los números que había en la
 lista original, tras medir el número de círculos en la cadena que es,
 efectivamente, el mismo. Obsérvese que el primer argumento de map es
 siempre una función. Map llamará a esa función una vez por cada elemento de la
-lista. 
+lista.
 
 `len` es una de las
 pocas
@@ -310,13 +310,13 @@ simplemente separados por espacios, así que `replicate rep "\#"`
 replica `rep` veces el asterisco, `concat $` lo reúne en una sola
 cadena, y por tanto, también de una forma un tanto complicada, crea
 "barras" con almohadillas "#" de la longitud de los diferentes
-elementos de la lista que se le pasa. 
+elementos de la lista que se le pasa.
 
 Haskell, como todos los lenguajes como los que hemos trabajado, tiene
 un REPL que se ejecuta desde la línea de órdenes, así que quizás
-convenga también 
+convenga también
 
-## aprender unas cuantas órdenes
+## Aprender unas cuantas órdenes
 
 que permiten trabajar con la misma. Estas órdenes corresponden al
 `shell` de Linux, que funciona, aunque posiblemente en una versión más
@@ -338,19 +338,19 @@ algunas órdenes útiles que funcionan en todos los intérpretes:
   `grep "TypeError: must" *` buscará exactamente esa frase; la única
   diferencia con el caso anterior es que rodeamos la cadena que se
   busca con comillas para que se busque íntegra.
-  
-* Se pueden crear directorios con `mkdir` y borrarse con `rmdir`. 
+
+* Se pueden crear directorios con `mkdir` y borrarse con `rmdir`.
 
 * La orden `find` también es muy útil. Tratamos de buscar el
   directorio donde metimos el dichoso fichero de Python, pues `find
   . -name *.py -print`. En realidad en PowerShell sólo busca en el
   directorio actual, pero en Linux descenderá por todos los
   directorios a partir de `.`, el directorio actual.
-  
+
 * `ls` lista todos los ficheros y directorios del directorio actual,
   incluyendo `.` y `..`, y `ls -alt` los muestra con permisos y los
   ordena por fecha de modificación.
-  
+
 ![ls -alt en PowerShell](../img/ps.png)
 
 DuckDuckGo, el buscador para
@@ -363,4 +363,3 @@ puedes tener como referencia a si quieres saber cómo se hace cualquier
 otra cosa. Los dos shells son muy potentes, y permiten crear programas
 potentes y expresivos. Conocerlos bien es un gran complemento al uso
 de cualquier lenguaje de programación.
-

--- a/txt/05.identificando.md
+++ b/txt/05.identificando.md
@@ -1,4 +1,4 @@
-# Dando nombre a las cosas.
+# Dando nombre a las cosas
 
 En los lenguajes de programación hay tantos objetos que hay que
 dividir el espacio de todos los nombres posibles para poder usar
@@ -13,7 +13,7 @@ identificadores. Ya hemos visto algunos de estos, los que se usan para
 designar a las funciones. Pero ya va siendo hora de que conozcamos a
 nuestras amigas
 
-## las variables.
+## Las variables
 
 Las variables almacenan objetos que vamos a usar más adelante;
 permiten hacer expresiones más claras y concisas y no tener que
@@ -22,7 +22,7 @@ almacena el último valor calculado en el intérprete. También otras
 variables como las que se usan en expresiones `lambda`, que más que
 para almacenar sirven para representar valores que se le pasan a una
 expresión, aunque tienen la misma forma sean para representar o para
-almacenar. 
+almacenar.
 
 El asunto de darle nombre a un objeto o
 expresión
@@ -32,7 +32,7 @@ no usar ni `l` ni `O` ni `I` porque seguro que habéis tenido que estar
 un momento pensando si se trata de un 0 o de un 1. El `_` es una forma
 conveniente de separar palabras en una variable, sustituyendo al
 espacio, de forma que se preferirá `es_primo` a `esPrimo`. Esta última
-convención se suele denominar *CamelCase* y conviene evitarla [por diversas razones](https://whathecode.wordpress.com/2011/02/10/camelcase-vs-underscores-scientific-showdown/). 
+convención se suele denominar *CamelCase* y conviene evitarla [por diversas razones](https://whathecode.wordpress.com/2011/02/10/camelcase-vs-underscores-scientific-showdown/).
 
 Las variables deben ser también descriptivas, como la siguiente:
 
@@ -53,13 +53,13 @@ convertimos el resultado a `list` por legibilidad. En este caso lo que
 estamos haciendo es hallar las cifras de una serie compuesta por las
 20 primeras potencias de dos. Para hallar las cifras de un número lo
 convertimos a una cadena con `str` y a continuación hallamos la
-longitud de esa cadena con `len`. 
+longitud de esa cadena con `len`.
 
 Trabajando con el REPL, las variables definidas se quedan en el mismo
 hasta que terminemos, y podemos usarlas en cálculos más adelante. Y,
 evidentemente, igual que las constantes que hemos venido usando, y
 como se ha visto al principio, tienen un tipo que se les asigna
-automáticamente. 
+automáticamente.
 
 ```Python
 type(potencias_de_2)
@@ -76,7 +76,7 @@ type(potencias_de_2)
 En el momento que se le vuelva a asignar un valor a la variable, el
 tipo cambia. En este caso se tratará de una *tupla*, que es también
 una secuencia y por tanto se le puede aplicar la función `map`
-anterior, pero en este caso una tupla es *inmutable*. 
+anterior, pero en este caso una tupla es *inmutable*.
 
 ```Python
 potencias_de_2.insert(64)
@@ -100,7 +100,7 @@ potencias_de_2
 ```
 
 donde se puede ver que, al tratarse de una lista y no una tupla, usa
-los corchetes y no los paréntesis. 
+los corchetes y no los paréntesis.
 
 > *Ejercicio*: Calcular los múltiplos de 3 entre los 100 primeros
 > números naturales. ¿Qué tipo de estructura de datos podemos usar?
@@ -114,14 +114,14 @@ menos directa. A calcular cuanto tiempo se tarda en realizar una
 operación se le llama hacer *benchmarking* y todos los lenguajes de
 programación vienen preparados para ello. Veremos como
 
-## medir la velocidad en Python.
+## Medir la velocidad en Python
 
 Pero primero vamos a ver cómo trabajar con Python desde la línea de
 órdenes. Cuando trabajamos en el REPL, se trata de un bucle en el que
 la `P` significa "imprimir", por lo que no nos tenemos que preocupar
 de eso; sin embargo, cuando tratamos de ejecutarlo desde la línea de
 órdenes del sistema, símbolo del sistema o como lo llames de forma
-habitual, siempre tendrá que estar envuelto en una orden `print`: 
+habitual, siempre tendrá que estar envuelto en una orden `print`:
 
 ```bash
 python -c "print(list(map(lambda n: n/2 == n//2, \
@@ -152,7 +152,7 @@ Hemos definido la función `es_par`, pero ahora nos encontramos con dos
 órdenes seguidas. Para que el intérprete lo entienda, las separamos
 con punto y coma. En Python se pueden separar todas las sentencias con
 `;`, pero realmente sólo es necesario cuando están en la misma línea,
-como se verá más adelante. 
+como se verá más adelante.
 
 Ahora cabría pensar si merece realmente la pena hacer esto. Es
 ligeramente más legible, lo que *está bien* desde el punto de vista de
@@ -190,7 +190,7 @@ no se crea una función cada vez que se ejecuta un bucle es más rápida,
 ejecutando eso nos va a dar más o menos el mismo resultado, que de
 hecho es el resultado que se obtiene prácticamente para todo. En este
 caso, para funciones tan simples, no resulta realmente demasiado
-útil. 
+útil.
 
 Probaremos desde el REPL, a ver si obtenemos algo más
 razonable. Importamos el módulo y la función del mismo que
@@ -248,23 +248,23 @@ que sea un 10% más rápido. Una vez más, si ésta no es una
 función crítica donde el sistema pasa el 90% del tiempo no vale la pena optimizar.
 
 En muchos casos, la mejor forma de optimizar es simplemente plantear
-algoritmos de otra forma. Por ejemplo, usando 
+algoritmos de otra forma. Por ejemplo, usando
 
-## recursión.
+## Recursión
 
 Se habla de recursión cuando una función se llama a sí misma. En
 programación funcional, resolver un problema usando recursión es la forma *normal* de hacer las cosas,
 suplantando la repetición. Uno de los principios de este tipo de
 programación es que las funcionen no tienen efectos secundarios; con
 la recursión se consigue *pasar* el estado como parámetro de una
-función sin tener que *guardarlo* en ningún momento. 
+función sin tener que *guardarlo* en ningún momento.
 
 En general, las funciones recursivas trabajan de la forma
 siguiente. Se compara el parámetro con el que marca el final de la
 recursión, que pueden ser uno o varios. Si es así, se devuelve el
 resultado. Si no, se llama a la función de nuevo con el parámetro
 procesado de alguna forma. Cuando se llega al final, se deshace la
-recursión y se devuelve el resultado. 
+recursión y se devuelve el resultado.
 
 La recursión funciona gracias a una estructura llamada [*pila* o *stack*](https://en.wikipedia.org/wiki/Stack_(abstract_data_type)). Una
 pila es una lista en la cual hay definidas sólo dos operaciones:
@@ -296,7 +296,7 @@ múltiplo de tres si la cifra resultante es 3 o 9.
 ```Python
 suma_cifras = lambda n:  sum(map(int,list(str(n))))
 def is_multiple_of_3(n): sum = suma_cifras(n); \
-  return is_multiple_of_3(sum) if (sum >= 10) \ 
+  return is_multiple_of_3(sum) if (sum >= 10) \
   else (True  if (sum==3) or (sum==9) else False)
 ```
 
@@ -307,7 +307,7 @@ caracteres que representan cifras, pero que tendremos que volver a
 convertir en números para poder sumarlos. Una vez más, se hace uso de dos
 técnicas de pensamiento computacional: buscar la representación
 adecuada para los datos, y crear la división de una operación en tres pasos (y
-eso en una sola línea). 
+eso en una sola línea).
 
 La recursividad se usa en la siguiente línea. Y es aquí donde tenemos que usar la
 forma tradicional de definir funciones de Python: `def`, porque con el
@@ -318,7 +318,7 @@ viene a ser un contrasentido; úsese sólo en caso de que sea más fácil
 de comprender que la forma alternativa o se pueda definir en una sola
 línea. Tras el nombre de la función `is_multiple_of_3` ponemos entre
 paréntesis el parámetro que vamos a usar en la misma y, como
-anteriormente, órdenes separadas por `;`. 
+anteriormente, órdenes separadas por `;`.
 
 La primera halla la suma de las cifras.
 La segunda usa la construcción Resultado `if` cierto `else` lo que
@@ -335,7 +335,7 @@ recursión queda más evidente. Si tiene más de una cifra (mayor que
 comprobar si es o no múltiplo de 3: ¿es 3 o 9? Se devuelve `True`;
 o `False` en caso contrario. El `return` al principio de la llamada
 recursiva es el que finalmente recoge el resultado. Al trabajar en el
-REPL habrá que pulsar ⤶ para indicar que termina ahí. 
+REPL habrá que pulsar ⤶ para indicar que termina ahí.
 
 > *Ejercicio*: usar una función recursiva para calcular el factorial
 > de un número. ¿Habría alguna otra forma de hacerlo? ¿Cuál es más
@@ -345,7 +345,7 @@ Podemos usar también recursión para calcular elementos de una sucesión
 que se defina de forma recursiva. En algunos lenguajes hay formas más
 compactas de hacerlo, por ejemplo en [Groovy](http://groovy-lang.org)
 definiríamos de esta forma el n-ésimo elemento de la sucesión de
-Fibonacci 
+Fibonacci
 
 ```Groovy
 def fib(n) {n<2 ? 1 : fib(n-1)+fib(n-2)}
@@ -356,16 +356,16 @@ mayoría de los lenguajes y que es similar al `if-else` en una sola
 línea de Python, con ? equivalente a `if` y `:` a `else`, aunque en
 otro orden: la comparación no es el segundo elemento, sino el
 primero. En este caso, si n es menor que dos se devuelve uno, si no se
-hace una llamada a la función sumando los dos elementos anteriores. 
+hace una llamada a la función sumando los dos elementos anteriores.
 
 > *Ejercicio*: usando una función recursiva equivalente a la anterior
 > en Python, calcular los 20 primeros elementos de la sucesión de
 > Fibonacci. ¿Hasta que número es más o menos razonable hacerlo de
-> esta forma? 
+> esta forma?
 
 Te estarás preguntando si todas estas líneas son solo bytes, y se
 perderán como lágrimas en la lluvia cuando se apague el
-ordenador. Pues sí, pero no tiene por qué ser así si usas 
+ordenador. Pues sí, pero no tiene por qué ser así si usas
 
 ## GitHub
 
@@ -373,7 +373,7 @@ Ya te indicamos al principio de todo que era un buen momento para
 registrarse en GitHub, pero ibas muy liada y no nos hiciste
 caso. Vale, pues ahora *sí* que lo es, porque lo vamos a usar para
 publicar todas estas líneas que vas elaborando como ejercicios y poder
-enseñárselas al profe y al ancho mundo. 
+enseñárselas al profe y al ancho mundo.
 
 [GitHub](https://github.com) es un portal de desarrollo colaborativo
 de software que usa `git` como herramienta de control de
@@ -388,7 +388,7 @@ Se puede usar eligiendo un nombre de fichero y copiando y pegando el
 contenido en el sitio correspondiente; el fichero se puede comentar
 usando el formato de comentarios del lenguaje correspondiente, por
 ejemplo, comenzando la línea con `#` en Python (y para el caso,
-también en Perl y Ruby). 
+también en Perl y Ruby).
 
 >*Ejercicio*: subir a gist.github.com alguno de los ejercicios creados
 >anteriormente, usando comentarios para explicarlo. Difundirlo también
@@ -424,7 +424,7 @@ apariencia que corresponda a las marcas incluidas.
 Realmente va a ser conveniente que usemos este tipo de repositorios
 cuando trabajemos con estructuras de datos más, complejas, como los
 
-## conjuntos y diccionarios.
+## Conjuntos y diccionarios
 
 Comencemos con los que se denominan *diccionarios*, aunque en otros
 lenguajes se les llama *arrays* asociativos o tablas *hash*. Los
@@ -432,9 +432,9 @@ diccionarios están compuestos por pares clave-valor; la clave es una
 cadena, el valor puede ser cualquier cosa.
 
 ```Python
-juego = { 'jugador'   :'Johnny', 
-         'mano'      : ['5♠','Q♣','8♥'], 
-		 'estrategia': lambda mano: min(mano) } 
+juego = { 'jugador'   :'Johnny',
+         'mano'      : ['5♠','Q♣','8♥'],
+		 'estrategia': lambda mano: min(mano) }
 ```
 
 Esta variable contiene información sobre una mano
@@ -443,7 +443,7 @@ Johnny, cuya estrategia está representada por una función `estrategia`
 que siempre saca el mínimo de todas las cartas. No es una buena
 estrategia, pero una mejor no cabría en esa línea. El formateo se ha
 incluido simplemente para que sea un poco más visible, pero no tiene
-ninguna importancia en la sintaxis. En este caso. 
+ninguna importancia en la sintaxis. En este caso.
 
 De la misma forma que en las listas se accede al contenido iterando
 de elemento en elemento, en este caso accederemos por la `clave` para
@@ -480,25 +480,25 @@ sepa que se ha acabado la definición de la función. En este caso:
 
 ```Python
 from random import random
-juego_ricky = { 
-  'jugador'   :'Ricky', 
-  'mano'      : ['3♠','4♣','A♥'], 
+juego_ricky = {
+  'jugador'   :'Ricky',
+  'mano'      : ['3♠','4♣','A♥'],
   'estrategia': lambda mano: mano[int(random()*len(mano))] }
-				
+
 juega(juego_ricky)
 '3♠'
 juega(juego_ricky)
 'A♥'
 ```
 
-Como hay un ``random()`` en la estrategia, la carta resultante será 
+Como hay un ``random()`` en la estrategia, la carta resultante será
 una aleatoria de entre las que Ricky tenga en su mano.
 
 > *Ejercicio*: diseñar una estructura de datos para sucesiones
 > matemáticas que contenga el nombre de la sucesión, el elemento
 > inicial, y la función para calcular el siguiente elemento. Diseñar
 > también una función que efectivamente calcule el siguiente elemento
-> a partir del valor inicial. 
+> a partir del valor inicial.
 
 En general, todos los lenguajes de programación que no son dinosaurios
 como el C suelen tener esta estructura de datos. Incluso lenguajes
@@ -506,7 +506,7 @@ específicos de dominio como el que incluye PowerShell. Este script,
 por ejemplo, define una tabla hash o diccionario:
 
 ```PowerShell
-$juego_ricky = @{ "jugador" ="Ricky"; "mano" = @("3♠","4♣","A♥")} 
+$juego_ricky = @{ "jugador" ="Ricky"; "mano" = @("3♠","4♣","A♥")}
 $juego_ricky
 ```
 
@@ -534,7 +534,7 @@ mano_ricky= set( ['3♠','4♣','A♥'] )
 
 En este caso hay que usar una palabra clave `set` para aclarar que se
 trata de este tipo de estructura de datos, pero también podríamos
-haber usado llaves, exactamente igual que con los diccionarios. 
+haber usado llaves, exactamente igual que con los diccionarios.
 Se puede comprobar si un elemento pertenece o no a un conjunto:
 
 ```Python
@@ -543,7 +543,7 @@ True
 ```
 
 > *Ejercicio*: generar una baraja de cartas y una función que extraiga
-> una mano de 3 cartas de ella. 
+> una mano de 3 cartas de ella.
 
 Los conjuntos
 tienen
@@ -587,7 +587,7 @@ carta superior, que es lo que se hace con `pop`. Usando `|`, que
 representa en este caso la unión entre conjuntos, se genera un
 conjunto de un solo elemento, como arriba, poniendo llaves alrededor y
 se une a la mano de Johnny. Ha sido un 10♦, eso es suerte, aunque como
-dicen en *The Gambler*, 
+dicen en *The Gambler*,
 
 >Cada mano es ganadora, cada mano es perdedora.
 
@@ -598,14 +598,14 @@ representar una serie de problemas, sean listas, datos que no son
 homogéneos y a los que se le puede asignar un significado para mejorar
 su comprensión y tratamiento, incluso conjuntos para representar
 aquellos grupos de objetos que no tengan ninguna relación entre sí más
-que la igualdad de su pertenencia al mismo grupo. 
+que la igualdad de su pertenencia al mismo grupo.
 
 Todos los objetos tienen sus propias operaciones, y amplían la
 capacidad de abstracción de los problemas que se pueden resolver. Como
-dicen también en *The Gambler*, 
+dicen también en *The Gambler*,
 
 >Si quieres jugar al juego, debes aprender a jugar bien.
 
 En este caso, debes aprender cómo trabajar con las diferentes
 estructuras de datos y cuál es la más adecuada en cada caso. Y en caso
-de duda, mide tiempos y sigue el Zen de Python. 
+de duda, mide tiempos y sigue el Zen de Python.

--- a/txt/06.sinpilas.md
+++ b/txt/06.sinpilas.md
@@ -5,7 +5,7 @@ espacio de nombres principal, es decir, sin prefijos, una serie de
 funciones, menos de 100. Ya hemos visto otras funciones, `timeit` y
 `random` que, aunque no estén *cargadas* por defecto, sí se pueden
 usar directamente siempre que las importemos en nuestro espacio de
-nombres. 
+nombres.
 
 Afortunadamente, el hecho de que Python sea software libre hace que se
 cree todo un ecosistema alrededor del mismo, con funciones que no
@@ -45,20 +45,20 @@ caso de la `baraja` que hemos mostrado en la imagen anterior, nos
 	tabulador; cuando seleccionamos uno y añadimos un paréntesis,
 	`bpython` nos explicará cuales son los parámetros que toma esta
 	función, lo que nos ahorra bastantes viajes a StackOverflow.
-	
+
 Vamos a usar a partir de ahora `bpython` para el resto del capítulo, y
 posiblemente del libro, así que conviene que esté convenientemente
 instalado a partir de este momento. Adicionalmente, eso significará
 que tienes permisos para instalarte cosas, sin el cual el resto del
-capítulo tampoco va a tener mucho sentido. 
+capítulo tampoco va a tener mucho sentido.
 
 Pero es posible que no tengas acceso a ningún ordenador de forma
 permanente. Estos tiempos bárbaros en los que la gente tiene acceso a
 cientos de ordenadores, pero ninguno de ellos tiene teclado o acceso
 de administrador, crean esas cosas. Así que nos tendremos que
-trasladar a 
+trasladar a
 
-## la nube.
+## La nube
 
 en una primera, y quizás mala, aproximación, la nube son recursos
 administrados por empresas que se pueden usar pagando sólo por el uso
@@ -83,13 +83,13 @@ puedes dar de alta, eso sí con una tarjeta de crédito, y usando tu ID
 de GitHub. Una vez dado de alta, se crea un *workspace* en Python con
 el nombre que uno quiera y automáticamente, con los ficheros y demás,
 aparece abajo una terminal desde la que se puede ejecutar el REPL de
-python y alguna cosa más. Se usa 
+python y alguna cosa más. Se usa
 
 ```
 sudo pip3 install bpython
 ```
 
-por ejemplo, para instalar el CLI con el que vamos a trabajar. 
+por ejemplo, para instalar el CLI con el que vamos a trabajar.
 
 
 ![usando `bpython` en Cloud9](../img/bpython-c9.io.png).
@@ -126,7 +126,7 @@ opciones:
 pip3 install --user bpython
 ```
 
-y posteriormente añadir 
+y posteriormente añadir
 
 ```
 export PATH=$PATH:~/.local/bin
@@ -142,12 +142,12 @@ Este *cloud shell* se desactiva y se borra a los 10 minutos de
 inactividad. Si realmente quieres conservar lo creado, o la historia,
 es mejor que uses una máquina virtual real, que tendrás que recordar
 apagar al final de cada sesión, porque todo consume y el crédito
-gratuito que se obtiene no es mucho. 
+gratuito que se obtiene no es mucho.
 
 Ya no tienes excusa para empezar a trabajar con `bpython` en la nube o
-donde sea. Así que vamos a ver el 
+donde sea. Así que vamos a ver el
 
-## Python más funcional,
+## Python más funcional
 
 en el sentido de la palabra: cómo trabajar con diferentes estructuras
 de datos siguiendo, dentro de lo posible, los preceptos de la
@@ -189,10 +189,10 @@ sort ['3♠','4♣','A♥'] Z sort ['7♣', '7♥', '7♦']
 Perl6 se ahorra paréntesis cuando no hacen falta y convierte `zip` en
 el operador infijo `Z`, es decir operador que, tal como los operadores
 matemáticos, está en medio de los operandos, en vez de al principio
-(lo que se suele denominar, en el caso de los operadores, *prefijo*). 
+(lo que se suele denominar, en el caso de los operadores, *prefijo*).
 
 > *Ejercicio*: crear una serie de fracciones, desde 1/3 hasta 1/99 y
-> hallar su suma. 
+> hallar su suma.
 
 Otra función, que estaba por alguna razón en Python 2 pero que ha sido
 exiliada a `functools` en Python 3 es `reduce`. Reduce aplica
@@ -220,14 +220,14 @@ un número por todos los que le preceden tal como estamos
 acostumbrados.
 
 > *Ejercicio*: Programar una función de Mandelbrot, usando números
-> complejos, de la misma forma. 
+> complejos, de la misma forma.
 
 No hace falta que el resultado final de un `reduce` sea un sólo
 número. Podemos por ejemplo ir creando una sucesión de Fibonacci,
 partiendo de un valor inicial: los dos primeros valores.
 
 ```Python
-def fib(n): 
+def fib(n):
     return reduce( lambda prev,this: \
 	prev+ [prev[-2]+prev[-1]], range(1,n+1), [1,1])
 fib(12)
@@ -240,7 +240,7 @@ fib(12)
 >que usan números arbitrarios como los números iniciales y que también
 >multiplican los términos anteriores por números naturales. Programar
 >la función `lucas` que genere estas sucesiones, y definir la función
->de Fibonacci como un caso particular de la misma. 
+>de Fibonacci como un caso particular de la misma.
 
 Esta misma función, `reduce`, está también presente en muchos otros
 lenguajes de programación. En JavaScript, por ejemplo, es uno de los
@@ -276,20 +276,20 @@ puede empezar a trabajar: hallar la suma, por ejemplo, o crear
 [las secuencias de Farey](http://nrich.maths.org/2086), que son
 secuencias de listas de fracciones. Por
 ejemplo,
-[se puede generar una aproximación al número e](https://en.wikipedia.org/wiki/Continued_fraction#A_property_of_the_golden_ratio_.CF.86). 
+[se puede generar una aproximación al número e](https://en.wikipedia.org/wiki/Continued_fraction#A_property_of_the_golden_ratio_.CF.86).
 
 Incluso de esta forma se pueden generar listas más complejas, como la
 multiplicación de dos vectores:
 
 ```Python
-[str(valor)+card for card in ["♠","♣","♥","♦"] 
+[str(valor)+card for card in ["♠","♣","♥","♦"]
     for valor in ['A','J','Q','K',2,3,4,5,6,7,8,9,10]]
 ```
 
 El primer `for` recorre los palos, el segundo los valores, y los dos
 juntos se unen, usando `+` para cadenas, en las cartas de la
 baraja. Usamos `str` alrededor de `valor` simplemente para ahorrarnos
-poner comillas alrededor de los números. 
+poner comillas alrededor de los números.
 
 > *Ejercicio*: para una urbanización con 4 bloques, 3 plantas por
 > bloque, dos pisos por planta, A y B, generar todos los posibles
@@ -316,7 +316,7 @@ y 1. `cuenta_pares` es la función que vamos a usar para reducir el
 array a un solo objeto. El primer argumento sería una lista. Usa el
 segundo argumento como un número, cuya paridad comprueba a base de
 hacer un `Y` por bits del último bit. Como el resultado es 0 o 1, usa
-`+=` para aumentar en 1 el valor de ese elemento de la lista. 
+`+=` para aumentar en 1 el valor de ese elemento de la lista.
 
 `+=` y en general cualquier operador más `=`, es una asignación que
 incluye el mismo elemento al que se asigna, es decir `loquesea =
@@ -354,7 +354,7 @@ usándose desde la época del C. Si ya hay una forma de hacerlo, usando
 > *Ejercicio*: Si habéis ejecutado el generador de números aleatorios
 > de arriba, habréis visto que rara vez el resultado es exactamente la
 > mitad de cada uno. ¿Cuanta desviación hay? Realizar una función que
-> contabilice la desviación del generador de números aleatorios. 
+> contabilice la desviación del generador de números aleatorios.
 
 
 
@@ -367,6 +367,4 @@ datos que se han elegido. Python no es exactamente un lenguaje
 funcional, pero los lenguajes modernos no pueden evitar tener ciertos
 rasgos funcionales, aunque no estén en las funciones base. Alguna
 función en un módulo como `functools` completa bastante bien el
-panorama. 
-
-
+panorama.

--- a/txt/07.entendiendo.md
+++ b/txt/07.entendiendo.md
@@ -1,4 +1,4 @@
-# Entendiendo el código de los demás.
+# Entendiendo el código de los demás
 
 En Informática se trabaja en equipos, aunque no siempre los equipos
 están en el mismo lugar y a la vez. Puede que te toque trabajar con un
@@ -7,7 +7,7 @@ así, tienes que entender su código y en muchos casos hacerle
 mejoras. En la mayoría de los casos resulta totalmente imposible
 tratar de comprenderlo, pero concentrándote en las líneas y usando un
 depurador, puedes conseguir al menos alterar el programa para que haga
-algo ligeramente diferente. 
+algo ligeramente diferente.
 
 Aún así, siempre se aprende algo. La programación es un medio de
 expresión que, como tal, tiene siempre un componente individual y,
@@ -23,7 +23,7 @@ libro. En realidad este código está desarrollado a partir de este otro
 https://github.com/psicobyte/PiMondrian de Pablo Hinojosa.
 
 > Ejercicio: a grandes rasgos, señalar las diferencias entre el
-> código. 
+> código.
 
 En estos casos, el buscador de GitHub siempre ayuda. Por ejemplo, te
 puede ayudar a buscar dónde se usa un identificador determinado, donde
@@ -32,7 +32,7 @@ permite buscar en todos los proyectos; es posible que ese código tenga
 algún cambio de estilo que delate que no fue escrito originalmente por
 el mismo autor: extendiendo la búsqueda a todo GitHub puedes ver el
 código original y entender quizás un poco mejor cuál era la intención
-del código. 
+del código.
 
 > Ejercicio: buscar dónde se definen los colores que se van a usar en
 > las diferentes subdivisiones del cuadro.
@@ -40,7 +40,7 @@ del código.
 El mismo efecto se puede conseguir, una vez descargado, usando `grep`
 
 	grep sequences_mondrian *.py
-	
+
 encontrará, por ejemplo, los diferentes *scripts* en los que se
 incluye, los dos que hay, al menos en el momento que se ha escrito
 esto.
@@ -50,7 +50,7 @@ alguna idea para mejorarlo. Por ejemplo ¿más colores? ¿Una
 distribución diferente de los mismos? ¿Algún código repetido que se
 pueda convertir en una función? Es el momento de
 
-## solicitar un *pull request*
+## Solicitar un *pull request*
 
 GitHub es en realidad una web que aloja proyectos gestionados con
 `git`, el sistema de control de fuentes distribuido. El hecho de que
@@ -65,7 +65,7 @@ Y hacerlo en GitHub es relativamente fácil: simplemente pulsando en el
 icono del lápiz editarás un fichero como tu propio usuario. En vez de
 simplemente guardarlo, al final aparece un botón que indica "Propose
 file change", es decir, proponer un cambio en el fichero, y dos textos
-tentativos que puedes cambiar para proponer un cambio en el mismo. 
+tentativos que puedes cambiar para proponer un cambio en el mismo.
 
 Cuando lo haces, no estás modificando el fichero original, sino tu
 copia del mismo. Con *propose file change* estás creando un *pull
@@ -75,11 +75,11 @@ una notificación y aprobará tus cambios, te propondrá que hagas algún
 cambio adicional, o lo rechazará. Dependerá de él, de su estilo y de
 la idea que tenga en la cabeza en su propio proyecto. No importa
 demasiado que no acepte los cambios: tratándose de software libre, tú
-puedes seguir desarrollando tu copia como desees. 
+puedes seguir desarrollando tu copia como desees.
 
 > *Ejercicio*: tomar alguno de los dos proyectos anteriores y sugerir
 > cambios a los autores. Si no, tomar alguno de algún proyecto que
-> resulte cercano o interese. 
+> resulte cercano o interese.
 
 ## Conclusión
 
@@ -89,4 +89,4 @@ mejores, que puedes leer, modificar, e incluso sugerir modificaciones
 al autor. Si la modificación es razonable, el autor la aceptará. Y si
 la haces en octubre, participa en
 el [Hacktoberfest](https://hacktoberfest.digitalocean.com/) y podrás
-ganar camisetas y pegatinas. 
+ganar camisetas y pegatinas.


### PR DESCRIPTION
He encontrado otra errata como la anterior de "los número ...". Está en la línea 274 del archivo **04.componiendo.md**

He corregido todos los títulos de secciones, poniéndoles la primera letra en mayúscula y quitándoles los . o , finales. Es solo una mera cuestión estética, para que tenga más coherencia visual a la hora de leerlo. Ej:
cambiar  
## perl mola,
por  
## Perl mola

Pero, que si lo habéis hecho "aposta" el que los títulos vayan así, nada más que rechazadme el pull request ;-)