### PR TITLE
Modificada definición de múltiplo de 3

### DIFF
--- a/txt/05.identificando.md
+++ b/txt/05.identificando.md
@@ -345,7 +345,7 @@ estamos tratando de condensar todo el Python posible en una sola
 línea, así que se perdona esta pequeña digresión, sobre todo porque la
 recursión queda más evidente. Si tiene más de una cifra (mayor que
 10), se sigue aplicando de forma recursiva. Si no, ya podemos
-comprobar si es o no múltiplo de 3: ¿es 3 o 9? Se devuelve `True`;
+comprobar si es o no múltiplo de 3: ¿es 3, 6 o 9? Se devuelve `True`;
 o `False` en caso contrario. El `return` al principio de la llamada
 recursiva es el que finalmente recoge el resultado. Al trabajar en el
 REPL habrá que pulsar ⤶ para indicar que termina ahí.

--- a/txt/05.identificando.md
+++ b/txt/05.identificando.md
@@ -300,7 +300,8 @@ encarga de llenar y posteriormente vaciar la pila. Así que vamos a
 crear una función de este tipo para averiguar si una cifra es múltiplo
 de tres lo que, recordando aritmética de primaria, resulta de sumar
 las cifras repetidamente hasta que resulta una sola, en cuyo caso será
-múltiplo de tres si la cifra resultante es 3 o 9.
+múltiplo de tres si la cifra resultante es 3, 6 o 9 (o 0, pero esto
+sólo pasa con el cero y no lo incluiremos por simplificar el código).
 
 ```Python
 suma_cifras = lambda n:  sum(map(int,list(str(n))))
@@ -308,7 +309,7 @@ def is_multiple_of_3(n):
   sum = suma_cifras(n);
   return is_multiple_of_3(sum) 
     if (sum >= 10) 
-    else (True  if (sum==3) or (sum==9) 
+    else (True  if (sum==3) or (sum==6) or (sum==9)
 	     else False)
 ```
 


### PR DESCRIPTION
Con la definición anterior, por ejemplo, no se contemplaban que números cuyas cifras suman 6 , como 6 o 15, fueran múltiplos de 3. Y ambos lo son (3x2=6, 3x5=15)

# Plantilla para *pull request*

Te agradecemos cualquier contribución que quieras hacer al libro, que aparecerá, en caso de ser aceptada, en la siguiente edición.

[x] He leído [las guías para contribuir](CONTRIBUTING.md)

